### PR TITLE
Remove ZWNJ from text

### DIFF
--- a/app/Bot/BotHelper.php
+++ b/app/Bot/BotHelper.php
@@ -50,7 +50,7 @@ class BotHelper {
     public function parsePrivateText(Update $update)
     {
         $chatId = $update->getMessage()->getChat()->getId();
-        $text   = $update->getMessage()->getText();
+        $text   = str_replace('‌', '', $update->getMessage()->getText());
 
         if (starts_with($text, 'ping')) {
             $this->telegram->sendMessage([


### PR DESCRIPTION
This fixes replying to messages containing Zero-width non-joiner character (like "ا‌بونتو").